### PR TITLE
DDCE-3903 | Updates needed for Java 11.

### DIFF
--- a/app/uk/gov/hmrc/merchandiseinbaggage/model/core/DeclarationJourney.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/model/core/DeclarationJourney.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.merchandiseinbaggage.model.core.DeclarationJourney._
 import uk.gov.hmrc.merchandiseinbaggage.service.{MibReferenceGenerator, PortService}
 import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
 
+import java.time.temporal.ChronoUnit
 import java.time.{Instant, LocalDateTime, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 import scala.util._
@@ -70,7 +71,9 @@ case class DeclarationJourney(
   sessionId: SessionId,
   declarationType: DeclarationType,
   journeyType: JourneyType = New,
-  createdAt: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC),
+  createdAt: LocalDateTime = LocalDateTime
+    .now(ZoneOffset.UTC)
+    .truncatedTo(ChronoUnit.MILLIS),
   maybeExciseOrRestrictedGoods: Option[YesNo] = None,
   maybeGoodsDestination: Option[GoodsDestination] = None,
   maybeValueWeightOfGoodsBelowThreshold: Option[YesNo] = None,
@@ -137,7 +140,7 @@ case class DeclarationJourney(
           maybeCustomsAgent,
           eori,
           journeyDetails,
-          LocalDateTime.now(),
+          LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS),
           mibReference
         )
       }
@@ -146,8 +149,9 @@ case class DeclarationJourney(
   val declarationRequiredAndComplete: Boolean = declarationIfRequiredAndComplete.isDefined
 
   val amendmentIfRequiredAndComplete: Option[Amendment] = journeyType match {
-    case New   => None
-    case Amend => goodsEntries.declarationGoodsIfComplete.map(goods => Amendment(1, LocalDateTime.now, goods))
+    case New => None
+    case Amend =>
+      goodsEntries.declarationGoodsIfComplete.map(goods => Amendment(1, LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS), goods))
   }
 
   val amendmentRequiredAndComplete: Boolean = amendmentIfRequiredAndComplete.isDefined

--- a/app/uk/gov/hmrc/merchandiseinbaggage/repositories/DeclarationJourneyRepository.scala
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/repositories/DeclarationJourneyRepository.scala
@@ -37,6 +37,7 @@ import org.mongodb.scala.result.UpdateResult
 import play.api.libs.json._
 import uk.gov.hmrc.mongo.play.json.formats.MongoFormats.objectIdFormat
 
+import java.time.temporal.ChronoUnit
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import scala.util.Try
 
@@ -80,7 +81,7 @@ class DeclarationJourneyRepository @Inject()(mongo: MongoComponent, val appConfi
   }
 
   def updateDate(documentIds: Seq[ObjectId]) = {
-    val time = LocalDateTime.now()
+    val time = LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)
     val zdt = ZonedDateTime.of(time, ZoneId.systemDefault())
 
     val selector = Filters.in("_id", documentIds: _*)

--- a/test/uk/gov/hmrc/merchandiseinbaggage/CoreTestData.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/CoreTestData.scala
@@ -35,6 +35,7 @@ import uk.gov.hmrc.merchandiseinbaggage.model.core._
 import uk.gov.hmrc.merchandiseinbaggage.smoketests.pages.ServiceTimeoutPage.fakeRequest
 import uk.gov.hmrc.merchandiseinbaggage.views.html.{DeclarationConfirmationView, Layout}
 
+import java.time.temporal.ChronoUnit
 import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
 
@@ -211,7 +212,7 @@ trait CoreTestData {
 
   val aAmendment = Amendment(
     1,
-    LocalDateTime.now,
+    LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS),
     DeclarationGoods(aGoods.copy(category = "more cheese") :: Nil),
     Some(TotalCalculationResult(aCalculationResults, AmountInPence(100), AmountInPence(100), AmountInPence(100), AmountInPence(100))),
     None

--- a/test/uk/gov/hmrc/merchandiseinbaggage/connectors/MibConnectorSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/connectors/MibConnectorSpec.scala
@@ -26,6 +26,7 @@ import uk.gov.hmrc.merchandiseinbaggage.utils.DataModelEnriched._
 import uk.gov.hmrc.merchandiseinbaggage.{BaseSpecWithApplication, CoreTestData}
 
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 class MibConnectorSpec extends BaseSpecWithApplication with CoreTestData with MibConfiguration {
 
@@ -49,7 +50,7 @@ class MibConnectorSpec extends BaseSpecWithApplication with CoreTestData with Mi
   }
 
   "send a calculation requests to backend for amend payment" in {
-    val amend = Amendment(111, LocalDateTime.now, DeclarationGoods(Seq(aImportGoods)))
+    val amend = Amendment(111, LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS), DeclarationGoods(Seq(aImportGoods)))
     val amendRequest = CalculationAmendRequest(Some(amend), Some(GreatBritain), aDeclarationId)
     val stubbedResults =
       CalculationResult(aGoods, AmountInPence(7835), AmountInPence(0), AmountInPence(1567), None) :: Nil

--- a/test/uk/gov/hmrc/merchandiseinbaggage/model/api/AmendmentSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/model/api/AmendmentSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.merchandiseinbaggage.model.api
 import uk.gov.hmrc.merchandiseinbaggage.{BaseSpec, CoreTestData}
 
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 class AmendmentSpec extends BaseSpec with CoreTestData {
 
@@ -26,11 +27,12 @@ class AmendmentSpec extends BaseSpec with CoreTestData {
     val stub = new JourneySourceFinder {
       override def findSource: Option[String] = Some("AssistedDigital")
     }
-    Amendment(1, LocalDateTime.now, aDeclarationGood, source = stub.findSource).source mustBe Some("AssistedDigital")
+    Amendment(1, LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS), aDeclarationGood, source = stub.findSource).source mustBe Some(
+      "AssistedDigital")
   }
 
   "populate the source to Digital if public facing" in new JourneySourceFinder {
     override lazy val isAssistedDigital: Boolean = false
-    Amendment(1, LocalDateTime.now, aDeclarationGood).source mustBe Some("Digital")
+    Amendment(1, LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS), aDeclarationGood).source mustBe Some("Digital")
   }
 }

--- a/test/uk/gov/hmrc/merchandiseinbaggage/model/core/DeclarationSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/model/core/DeclarationSpec.scala
@@ -29,6 +29,7 @@ import uk.gov.hmrc.merchandiseinbaggage.utils.DateUtils._
 import uk.gov.hmrc.merchandiseinbaggage.utils.Obfuscate._
 import uk.gov.hmrc.merchandiseinbaggage.{BaseSpecWithApplication, CoreTestData}
 
+import java.time.temporal.ChronoUnit
 import java.time.{LocalDate, LocalDateTime}
 import java.util.UUID
 
@@ -172,7 +173,7 @@ class DeclarationSpec extends BaseSpecWithApplication with CoreTestData {
 
     "be complete" when {
       "the user has completed the journey" in {
-        val now = LocalDateTime.now
+        val now = LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS)
         val reference = MibReference("xx")
         val declarationId = DeclarationId(UUID.randomUUID().toString)
         completedDeclarationJourney.declarationIfRequiredAndComplete
@@ -390,7 +391,7 @@ class DeclarationSpec extends BaseSpecWithApplication with CoreTestData {
         JourneyDetailsEntry("BH", LocalDate.now).dateOfTravel,
         "Lx123"
       ),
-      LocalDateTime.now(),
+      LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS),
       MibReference("xx"),
       source = stub.findSource
     ).source mustBe Some("AssistedDigital")
@@ -412,21 +413,21 @@ class DeclarationSpec extends BaseSpecWithApplication with CoreTestData {
         JourneyDetailsEntry("BH", LocalDate.now).dateOfTravel,
         "Lx123"
       ),
-      LocalDateTime.now(),
+      LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS),
       MibReference("xx"),
       None,
       amendments = Seq.empty
     )
 
-    val latestAmendment = aAmendment.modify(_.dateOfAmendment).setTo(LocalDateTime.now().minusMinutes(10))
+    val latestAmendment = aAmendment.modify(_.dateOfAmendment).setTo(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS).minusMinutes(10))
 
     declarationWithGoods.latestGoods mustBe declarationWithGoods.declarationGoods.goods
     declarationWithGoods
       .modify(_.amendments)
       .setTo(Seq(
-        aAmendment.modify(_.dateOfAmendment).setTo(LocalDateTime.now()),
-        aAmendment.modify(_.dateOfAmendment).setTo(LocalDateTime.now().minusDays(1)),
-        aAmendment.modify(_.dateOfAmendment).setTo(LocalDateTime.now().plusMinutes(1)),
+        aAmendment.modify(_.dateOfAmendment).setTo(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS)),
+        aAmendment.modify(_.dateOfAmendment).setTo(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS).minusDays(1)),
+        aAmendment.modify(_.dateOfAmendment).setTo(LocalDateTime.now().truncatedTo(ChronoUnit.MILLIS).plusMinutes(1)),
         latestAmendment
       ))
       .latestGoods mustBe latestAmendment.goods.goods

--- a/test/uk/gov/hmrc/merchandiseinbaggage/smoketests/AdditionalDeclarationExportSpec.scala
+++ b/test/uk/gov/hmrc/merchandiseinbaggage/smoketests/AdditionalDeclarationExportSpec.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.merchandiseinbaggage.smoketests.pages._
 import uk.gov.hmrc.merchandiseinbaggage.stubs.MibBackendStub._
 
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 class AdditionalDeclarationExportSpec extends BaseUiSpec {
 
@@ -41,7 +42,7 @@ class AdditionalDeclarationExportSpec extends BaseUiSpec {
       givenFindByDeclarationReturnSuccess(mibReference, eori, paidDeclaration)
 
       val sessionId = SessionId()
-      val created = LocalDateTime.now
+      val created = LocalDateTime.now.truncatedTo(ChronoUnit.MILLIS)
       val id = paidDeclaration.declarationId
       val exportJourney: DeclarationJourney = completedDeclarationJourney
         .copy(


### PR DESCRIPTION
Added .truncatedTo(ChronoUnit.MILLIS) to LocalDateTime.now to solve problems with precision, as mentioned in migration guide. 

Run integration, acceptance, performance tests locally with J11. All passed.