### PR TITLE
DDCE-4601: Fix blocked print link on DeclarationConfirmationView

### DIFF
--- a/app/uk/gov/hmrc/merchandiseinbaggage/views/DeclarationConfirmationView.scala.html
+++ b/app/uk/gov/hmrc/merchandiseinbaggage/views/DeclarationConfirmationView.scala.html
@@ -35,8 +35,9 @@
 @printLink = {
  <script @{CSPNonce.attr}>
   document.getElementById("printLink").classList.remove("govuk-!-display-none");
-  document.getElementById("printLink").classList.add("govuk-body", "govuk-!-display-none-print")
-  document.getElementById("printLink").setAttribute("aria-hidden", "false")
+  document.getElementById("printLink").classList.add("govuk-body", "govuk-!-display-none-print");
+  document.getElementById("printLink").setAttribute("aria-hidden", "false");
+  document.getElementById("printDeclarationId").addEventListener("click", () => window.print());
  </script>
 }
 
@@ -67,7 +68,7 @@
 </dl>
 
  <p id="printLink" class="govuk-!-display-none" aria-hidden="true">
-   <a id="printDeclarationId" class="govuk-link" href="javascript:window.print();">@messages("declarationConfirmation.printOrSave.label")</a>
+   <a id="printDeclarationId" class="govuk-link">@messages("declarationConfirmation.printOrSave.label")</a>
  </p>
 
  <h2 id="whatToDoNextId" class="govuk-heading-m">@messages("declarationConfirmation.h2.1")</h2>


### PR DESCRIPTION
### DDCE-4601: Fix blocked print link on DeclarationConfirmationView

- During [CSP policy change](https://jira.tools.tax.service.gov.uk/browse/DDCE-4171), the inline print javascript was not covered by a Nonce on DeclarationConfirmationView.