### PR TITLE
DDCE-6180 - updating the dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import uk.gov.hmrc.DefaultBuildSettings.itSettings
 
-ThisBuild / scalaVersion := "2.13.14"
+ThisBuild / scalaVersion := "2.13.15"
 ThisBuild / majorVersion := 0
 
 lazy val microservice = Project("merchandise-in-baggage-frontend", file("."))

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,7 +6,7 @@ object AppDependencies {
 
   private val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"                %% "bootstrap-frontend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc"                %% "play-frontend-hmrc-play-30" % "10.13.0",
+    "uk.gov.hmrc"                %% "play-frontend-hmrc-play-30" % "11.3.0",
     "uk.gov.hmrc.mongo"          %% "hmrc-mongo-play-30"         % "2.3.0",
     "com.beachape"               %% "enumeratum-play"            % "1.8.2",
     "org.webjars.npm"             % "accessible-autocomplete"    % "3.0.0",


### PR DESCRIPTION
ignored the pakko update to 1.3.0 as it requires additional dependency updates.

>  You are using version 1.1.2 of Apache Pekko, but it appears you (perhaps indirectly) also depend on older versions of related artifacts. You can solve this by adding an explicit dependency on version 1.1.2 of the [pekko-protobuf-v3, pekko-serialization-jackson, pekko-stream] artifacts to your project. Here's a complete collection of detected artifacts: (1.0.3, [pekko-protobuf-v3, pekko-serialization-jackson, pekko-stream]), (1.1.2, [pekko-actor, pekko-actor-typed, pekko-slf4j]). See also: https://pekko.apache.org/docs/pekko/current/common/binary-compatibility-rules.html#mixed-versioning-is-not-allowed
